### PR TITLE
Add incantations and reordering

### DIFF
--- a/app/components/AncestryTraitsTab.tsx
+++ b/app/components/AncestryTraitsTab.tsx
@@ -81,22 +81,22 @@ const AncestryTraitsTab = ({ ancestryTraits, onChange }) => {
                   }
                 />
               </div>
-              <div className="flex flex-col ml-2 opacity-0 group-hover:opacity-100 focus-within:opacity-100">
+              <div className="flex flex-col ml-2">
                 <button
                   className="text-gray-500 hover:text-gray-700"
                   onClick={() => moveTrait(index, -1)}
                 >
-                  <ArrowUp className="h-4 w-4" />
+                  <ArrowUp className="h-5 w-5" />
                 </button>
                 <button
                   className="text-gray-500 hover:text-gray-700"
                   onClick={() => moveTrait(index, 1)}
                 >
-                  <ArrowDown className="h-4 w-4" />
+                  <ArrowDown className="h-5 w-5" />
                 </button>
               </div>
               <button
-                className="ml-2 text-red-500 hover:text-red-700 opacity-0 group-hover:opacity-100 focus-within:opacity-100"
+                className="ml-2 text-red-500 hover:text-red-700"
                 onClick={() => handleRemoveAncestryTrait(index)}
               >
                 <Trash2 className="h-6 w-6" />

--- a/app/components/AncestryTraitsTab.tsx
+++ b/app/components/AncestryTraitsTab.tsx
@@ -50,7 +50,7 @@ const AncestryTraitsTab = ({ ancestryTraits, onChange }) => {
         ancestryTraits.map((trait, index) => (
           <div
             key={index}
-            className="bg-white p-4 rounded-lg border border-gray-200 mb-4"
+            className="bg-white p-4 rounded-lg border border-gray-200 mb-4 group"
           >
             <div className="flex items-start">
               <div className="flex-1">
@@ -81,7 +81,7 @@ const AncestryTraitsTab = ({ ancestryTraits, onChange }) => {
                   }
                 />
               </div>
-              <div className="flex flex-col ml-2">
+              <div className="flex flex-col ml-2 opacity-0 group-hover:opacity-100 focus-within:opacity-100">
                 <button
                   className="text-gray-500 hover:text-gray-700"
                   onClick={() => moveTrait(index, -1)}
@@ -96,7 +96,7 @@ const AncestryTraitsTab = ({ ancestryTraits, onChange }) => {
                 </button>
               </div>
               <button
-                className="ml-2 text-red-500 hover:text-red-700"
+                className="ml-2 text-red-500 hover:text-red-700 opacity-0 group-hover:opacity-100 focus-within:opacity-100"
                 onClick={() => handleRemoveAncestryTrait(index)}
               >
                 <Trash2 className="h-6 w-6" />

--- a/app/components/AncestryTraitsTab.tsx
+++ b/app/components/AncestryTraitsTab.tsx
@@ -1,4 +1,4 @@
-import { Trash2, Plus } from "lucide-react";
+import { Trash2, Plus, ArrowUp, ArrowDown } from "lucide-react";
 
 const AncestryTraitsTab = ({ ancestryTraits, onChange }) => {
   // Add a new ancestry trait
@@ -19,6 +19,15 @@ const AncestryTraitsTab = ({ ancestryTraits, onChange }) => {
       [field]: value,
     };
     onChange(updatedAncestryTraits);
+  };
+
+  const moveTrait = (index, direction) => {
+    const newIndex = index + direction;
+    if (newIndex < 0 || newIndex >= ancestryTraits.length) return;
+    const updated = [...ancestryTraits];
+    const [moved] = updated.splice(index, 1);
+    updated.splice(newIndex, 0, moved);
+    onChange(updated);
   };
 
   return (
@@ -72,8 +81,22 @@ const AncestryTraitsTab = ({ ancestryTraits, onChange }) => {
                   }
                 />
               </div>
+              <div className="flex flex-col ml-2">
+                <button
+                  className="text-gray-500 hover:text-gray-700"
+                  onClick={() => moveTrait(index, -1)}
+                >
+                  <ArrowUp className="h-4 w-4" />
+                </button>
+                <button
+                  className="text-gray-500 hover:text-gray-700"
+                  onClick={() => moveTrait(index, 1)}
+                >
+                  <ArrowDown className="h-4 w-4" />
+                </button>
+              </div>
               <button
-                className="ml-4 text-red-500 hover:text-red-700"
+                className="ml-2 text-red-500 hover:text-red-700"
                 onClick={() => handleRemoveAncestryTrait(index)}
               >
                 <Trash2 className="h-6 w-6" />

--- a/app/components/EquipmentTab.tsx
+++ b/app/components/EquipmentTab.tsx
@@ -1,4 +1,4 @@
-import { Trash2, Plus } from "lucide-react";
+import { Trash2, Plus, ArrowUp, ArrowDown } from "lucide-react";
 
 const EquipmentTab = ({ equipment, onChange }) => {
   // Update currency
@@ -42,6 +42,53 @@ const EquipmentTab = ({ equipment, onChange }) => {
     };
 
     onChange(updatedEquipment);
+  };
+
+  // Move item up or down
+  const moveItem = (index, direction) => {
+    const newIndex = index + direction;
+    if (newIndex < 0 || newIndex >= equipment.items.length) return;
+    const updatedItems = [...equipment.items];
+    const [moved] = updatedItems.splice(index, 1);
+    updatedItems.splice(newIndex, 0, moved);
+    onChange({ ...equipment, items: updatedItems });
+  };
+
+  // ------------------
+  // Incantations
+  // ------------------
+  const handleAddIncantation = () => {
+    const updated = {
+      ...equipment,
+      incantations: [
+        ...(equipment.incantations || []),
+        { name: "", castingNumber: 0, description: "" },
+      ],
+    };
+    onChange(updated);
+  };
+
+  const handleRemoveIncantation = (index) => {
+    const updated = {
+      ...equipment,
+      incantations: (equipment.incantations || []).filter((_, i) => i !== index),
+    };
+    onChange(updated);
+  };
+
+  const handleUpdateIncantation = (index, field, value) => {
+    const list = [...(equipment.incantations || [])];
+    list[index] = { ...list[index], [field]: value };
+    onChange({ ...equipment, incantations: list });
+  };
+
+  const moveIncantation = (index, direction) => {
+    const list = [...(equipment.incantations || [])];
+    const newIndex = index + direction;
+    if (newIndex < 0 || newIndex >= list.length) return;
+    const [moved] = list.splice(index, 1);
+    list.splice(newIndex, 0, moved);
+    onChange({ ...equipment, incantations: list });
   };
 
   return (
@@ -142,12 +189,92 @@ const EquipmentTab = ({ equipment, onChange }) => {
                   onChange={(e) => handleUpdateItem(index, e.target.value)}
                 />
               </div>
+              <div className="flex flex-col ml-2">
+                <button
+                  className="text-gray-500 hover:text-gray-700"
+                  onClick={() => moveItem(index, -1)}
+                >
+                  <ArrowUp className="h-4 w-4" />
+                </button>
+                <button
+                  className="text-gray-500 hover:text-gray-700"
+                  onClick={() => moveItem(index, 1)}
+                >
+                  <ArrowDown className="h-4 w-4" />
+                </button>
+              </div>
               <button
-                className="ml-4 text-red-500 hover:text-red-700"
+                className="ml-2 text-red-500 hover:text-red-700"
                 onClick={() => handleRemoveItem(index)}
               >
                 <Trash2 className="h-6 w-6" />
               </button>
+            </div>
+          </div>
+        ))
+      )}
+
+      {/* Incantations */}
+      <div className="flex justify-between items-center mt-8 mb-6">
+        <h3 className="text-xl font-medium">Incantations</h3>
+        <button
+          className="bg-blue-600 text-white px-4 py-2 rounded-md flex items-center"
+          onClick={handleAddIncantation}
+        >
+          <Plus className="mr-1 h-4 w-4" />
+          Add Incantation
+        </button>
+      </div>
+
+      {(equipment.incantations || []).length === 0 ? (
+        <div className="text-center py-12 text-gray-500 bg-white p-4 rounded-lg border border-gray-200">
+          No incantations added yet.
+        </div>
+      ) : (
+        (equipment.incantations || []).map((inc, index) => (
+          <div
+            key={index}
+            className="bg-white p-4 rounded-lg border border-gray-200 mb-4"
+          >
+            <div className="grid grid-cols-1 md:grid-cols-4 gap-4 items-center">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Name</label>
+                <input
+                  type="text"
+                  className="w-full p-2 border border-gray-300 rounded-md"
+                  value={inc.name || ""}
+                  onChange={(e) => handleUpdateIncantation(index, "name", e.target.value)}
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Casting #</label>
+                <input
+                  type="number"
+                  className="w-full p-2 border border-gray-300 rounded-md"
+                  value={inc.castingNumber || 0}
+                  onChange={(e) => handleUpdateIncantation(index, "castingNumber", parseInt(e.target.value) || 0)}
+                />
+              </div>
+              <div className="md:col-span-2">
+                <label className="block text-sm font-medium text-gray-700 mb-1">Description</label>
+                <textarea
+                  className="w-full p-2 border border-gray-300 rounded-md"
+                  rows={2}
+                  value={inc.description || ""}
+                  onChange={(e) => handleUpdateIncantation(index, "description", e.target.value)}
+                />
+              </div>
+              <div className="flex items-start space-x-2">
+                <button className="text-gray-500 hover:text-gray-700" onClick={() => moveIncantation(index, -1)}>
+                  <ArrowUp className="h-4 w-4" />
+                </button>
+                <button className="text-gray-500 hover:text-gray-700" onClick={() => moveIncantation(index, 1)}>
+                  <ArrowDown className="h-4 w-4" />
+                </button>
+                <button className="text-red-500 hover:text-red-700" onClick={() => handleRemoveIncantation(index)}>
+                  <Trash2 className="h-5 w-5" />
+                </button>
+              </div>
             </div>
           </div>
         ))

--- a/app/components/EquipmentTab.tsx
+++ b/app/components/EquipmentTab.tsx
@@ -254,22 +254,22 @@ const EquipmentTab = ({
                   onChange={(e) => handleUpdateItem(index, e.target.value)}
                 />
               </div>
-              <div className="flex flex-col ml-2 opacity-0 group-hover:opacity-100 focus-within:opacity-100">
+              <div className="flex flex-col ml-2">
                 <button
                   className="text-gray-500 hover:text-gray-700"
                   onClick={() => moveItem(index, -1)}
                 >
-                  <ArrowUp className="h-4 w-4" />
+                  <ArrowUp className="h-5 w-5" />
                 </button>
                 <button
                   className="text-gray-500 hover:text-gray-700"
                   onClick={() => moveItem(index, 1)}
                 >
-                  <ArrowDown className="h-4 w-4" />
+                  <ArrowDown className="h-5 w-5" />
                 </button>
               </div>
               <button
-                className="ml-2 text-red-500 hover:text-red-700 opacity-0 group-hover:opacity-100 focus-within:opacity-100"
+                className="ml-2 text-red-500 hover:text-red-700"
                 onClick={() => handleRemoveItem(index)}
               >
                 <Trash2 className="h-6 w-6" />
@@ -320,12 +320,12 @@ const EquipmentTab = ({
                   onChange={(e) => handleUpdateIncantation(index, "description", e.target.value)}
                 />
               </div>
-              <div className="flex items-start space-x-2 opacity-0 group-hover:opacity-100 focus-within:opacity-100">
+              <div className="flex items-start space-x-2">
                 <button className="text-gray-500 hover:text-gray-700" onClick={() => moveIncantation(index, -1)}>
-                  <ArrowUp className="h-4 w-4" />
+                  <ArrowUp className="h-5 w-5" />
                 </button>
                 <button className="text-gray-500 hover:text-gray-700" onClick={() => moveIncantation(index, 1)}>
-                  <ArrowDown className="h-4 w-4" />
+                  <ArrowDown className="h-5 w-5" />
                 </button>
                 <button className="text-red-500 hover:text-red-700" onClick={() => handleRemoveIncantation(index)}>
                   <Trash2 className="h-5 w-5" />
@@ -392,15 +392,15 @@ const EquipmentTab = ({
                     value={weapon.properties || ""}
                     onChange={(e) => handleUpdateWeapon(index, "properties", e.target.value)}
                   />
-                  <div className="flex flex-col opacity-0 group-hover:opacity-100 focus-within:opacity-100">
+                  <div className="flex flex-col">
                     <button className="text-gray-500 hover:text-gray-700" onClick={() => moveWeapon(index, -1)}>
-                      <ArrowUp className="h-4 w-4" />
+                      <ArrowUp className="h-5 w-5" />
                     </button>
                     <button className="text-gray-500 hover:text-gray-700" onClick={() => moveWeapon(index, 1)}>
-                      <ArrowDown className="h-4 w-4" />
+                      <ArrowDown className="h-5 w-5" />
                     </button>
                   </div>
-                  <button className="bg-red-500 text-white p-2 rounded-r-md hover:bg-red-600 ml-1 opacity-0 group-hover:opacity-100 focus-within:opacity-100" onClick={() => handleRemoveWeapon(index)}>
+                  <button className="bg-red-500 text-white p-2 rounded-r-md hover:bg-red-600 ml-1" onClick={() => handleRemoveWeapon(index)}>
                     <Trash2 className="h-5 w-5" />
                   </button>
                 </div>
@@ -457,15 +457,15 @@ const EquipmentTab = ({
                     value={a.properties || ""}
                     onChange={(e) => handleUpdateArmor(index, "properties", e.target.value)}
                   />
-                  <div className="flex flex-col opacity-0 group-hover:opacity-100 focus-within:opacity-100">
+                  <div className="flex flex-col">
                     <button className="text-gray-500 hover:text-gray-700" onClick={() => moveArmor(index, -1)}>
-                      <ArrowUp className="h-4 w-4" />
+                      <ArrowUp className="h-5 w-5" />
                     </button>
                     <button className="text-gray-500 hover:text-gray-700" onClick={() => moveArmor(index, 1)}>
-                      <ArrowDown className="h-4 w-4" />
+                      <ArrowDown className="h-5 w-5" />
                     </button>
                   </div>
-                  <button className="bg-red-500 text-white p-2 rounded-r-md hover:bg-red-600 ml-1 opacity-0 group-hover:opacity-100 focus-within:opacity-100" onClick={() => handleRemoveArmor(index)}>
+                  <button className="bg-red-500 text-white p-2 rounded-r-md hover:bg-red-600 ml-1" onClick={() => handleRemoveArmor(index)}>
                     <Trash2 className="h-5 w-5" />
                   </button>
                 </div>

--- a/app/components/EquipmentTab.tsx
+++ b/app/components/EquipmentTab.tsx
@@ -1,6 +1,13 @@
 import { Trash2, Plus, ArrowUp, ArrowDown } from "lucide-react";
 
-const EquipmentTab = ({ equipment, onChange }) => {
+const EquipmentTab = ({
+  equipment,
+  weapons,
+  armor,
+  onEquipmentChange,
+  onWeaponsChange,
+  onArmorChange,
+}) => {
   // Update currency
   const handleCurrencyChange = (currency, value) => {
     const updatedEquipment = {
@@ -10,7 +17,7 @@ const EquipmentTab = ({ equipment, onChange }) => {
         [currency]: value,
       },
     };
-    onChange(updatedEquipment);
+    onEquipmentChange(updatedEquipment);
   };
 
   // Add a new item
@@ -19,7 +26,7 @@ const EquipmentTab = ({ equipment, onChange }) => {
       ...equipment,
       items: [...equipment.items, { name: "" }],
     };
-    onChange(updatedEquipment);
+    onEquipmentChange(updatedEquipment);
   };
 
   // Remove an item
@@ -28,7 +35,7 @@ const EquipmentTab = ({ equipment, onChange }) => {
       ...equipment,
       items: equipment.items.filter((_, i) => i !== index),
     };
-    onChange(updatedEquipment);
+    onEquipmentChange(updatedEquipment);
   };
 
   // Update an item
@@ -41,7 +48,7 @@ const EquipmentTab = ({ equipment, onChange }) => {
       items: updatedItems,
     };
 
-    onChange(updatedEquipment);
+    onEquipmentChange(updatedEquipment);
   };
 
   // Move item up or down
@@ -51,7 +58,7 @@ const EquipmentTab = ({ equipment, onChange }) => {
     const updatedItems = [...equipment.items];
     const [moved] = updatedItems.splice(index, 1);
     updatedItems.splice(newIndex, 0, moved);
-    onChange({ ...equipment, items: updatedItems });
+    onEquipmentChange({ ...equipment, items: updatedItems });
   };
 
   // ------------------
@@ -62,10 +69,10 @@ const EquipmentTab = ({ equipment, onChange }) => {
       ...equipment,
       incantations: [
         ...(equipment.incantations || []),
-        { name: "", castingNumber: 0, description: "" },
+        { name: "", description: "" },
       ],
     };
-    onChange(updated);
+    onEquipmentChange(updated);
   };
 
   const handleRemoveIncantation = (index) => {
@@ -73,13 +80,13 @@ const EquipmentTab = ({ equipment, onChange }) => {
       ...equipment,
       incantations: (equipment.incantations || []).filter((_, i) => i !== index),
     };
-    onChange(updated);
+    onEquipmentChange(updated);
   };
 
   const handleUpdateIncantation = (index, field, value) => {
     const list = [...(equipment.incantations || [])];
     list[index] = { ...list[index], [field]: value };
-    onChange({ ...equipment, incantations: list });
+    onEquipmentChange({ ...equipment, incantations: list });
   };
 
   const moveIncantation = (index, direction) => {
@@ -88,7 +95,65 @@ const EquipmentTab = ({ equipment, onChange }) => {
     if (newIndex < 0 || newIndex >= list.length) return;
     const [moved] = list.splice(index, 1);
     list.splice(newIndex, 0, moved);
-    onChange({ ...equipment, incantations: list });
+    onEquipmentChange({ ...equipment, incantations: list });
+  };
+
+  // ------------------
+  // Weapons helpers
+  // ------------------
+  const handleAddWeapon = () => {
+    onWeaponsChange([
+      ...weapons,
+      { name: "", modifier: 0, damage: "", properties: "" },
+    ]);
+  };
+
+  const moveWeapon = (index, direction) => {
+    const newIndex = index + direction;
+    if (newIndex < 0 || newIndex >= weapons.length) return;
+    const updated = [...weapons];
+    const [moved] = updated.splice(index, 1);
+    updated.splice(newIndex, 0, moved);
+    onWeaponsChange(updated);
+  };
+
+  const handleRemoveWeapon = (index) => {
+    onWeaponsChange(weapons.filter((_, i) => i !== index));
+  };
+
+  const handleUpdateWeapon = (index, field, value) => {
+    const updated = [...weapons];
+    updated[index] = { ...updated[index], [field]: value };
+    onWeaponsChange(updated);
+  };
+
+  // ------------------
+  // Armor helpers
+  // ------------------
+  const handleAddArmor = () => {
+    onArmorChange([
+      ...armor,
+      { name: "", rating: 0, properties: "" },
+    ]);
+  };
+
+  const moveArmor = (index, direction) => {
+    const newIndex = index + direction;
+    if (newIndex < 0 || newIndex >= armor.length) return;
+    const updated = [...armor];
+    const [moved] = updated.splice(index, 1);
+    updated.splice(newIndex, 0, moved);
+    onArmorChange(updated);
+  };
+
+  const handleRemoveArmor = (index) => {
+    onArmorChange(armor.filter((_, i) => i !== index));
+  };
+
+  const handleUpdateArmor = (index, field, value) => {
+    const updated = [...armor];
+    updated[index] = { ...updated[index], [field]: value };
+    onArmorChange(updated);
   };
 
   return (
@@ -175,7 +240,7 @@ const EquipmentTab = ({ equipment, onChange }) => {
         equipment.items.map((item, index) => (
           <div
             key={index}
-            className="bg-white p-4 rounded-lg border border-gray-200 mb-4"
+            className="bg-white p-4 rounded-lg border border-gray-200 mb-4 group"
           >
             <div className="flex items-center">
               <div className="flex-1">
@@ -189,7 +254,7 @@ const EquipmentTab = ({ equipment, onChange }) => {
                   onChange={(e) => handleUpdateItem(index, e.target.value)}
                 />
               </div>
-              <div className="flex flex-col ml-2">
+              <div className="flex flex-col ml-2 opacity-0 group-hover:opacity-100 focus-within:opacity-100">
                 <button
                   className="text-gray-500 hover:text-gray-700"
                   onClick={() => moveItem(index, -1)}
@@ -204,7 +269,7 @@ const EquipmentTab = ({ equipment, onChange }) => {
                 </button>
               </div>
               <button
-                className="ml-2 text-red-500 hover:text-red-700"
+                className="ml-2 text-red-500 hover:text-red-700 opacity-0 group-hover:opacity-100 focus-within:opacity-100"
                 onClick={() => handleRemoveItem(index)}
               >
                 <Trash2 className="h-6 w-6" />
@@ -234,7 +299,7 @@ const EquipmentTab = ({ equipment, onChange }) => {
         (equipment.incantations || []).map((inc, index) => (
           <div
             key={index}
-            className="bg-white p-4 rounded-lg border border-gray-200 mb-4"
+            className="bg-white p-4 rounded-lg border border-gray-200 mb-4 group"
           >
             <div className="grid grid-cols-1 md:grid-cols-4 gap-4 items-center">
               <div>
@@ -246,15 +311,6 @@ const EquipmentTab = ({ equipment, onChange }) => {
                   onChange={(e) => handleUpdateIncantation(index, "name", e.target.value)}
                 />
               </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Casting #</label>
-                <input
-                  type="number"
-                  className="w-full p-2 border border-gray-300 rounded-md"
-                  value={inc.castingNumber || 0}
-                  onChange={(e) => handleUpdateIncantation(index, "castingNumber", parseInt(e.target.value) || 0)}
-                />
-              </div>
               <div className="md:col-span-2">
                 <label className="block text-sm font-medium text-gray-700 mb-1">Description</label>
                 <textarea
@@ -264,7 +320,7 @@ const EquipmentTab = ({ equipment, onChange }) => {
                   onChange={(e) => handleUpdateIncantation(index, "description", e.target.value)}
                 />
               </div>
-              <div className="flex items-start space-x-2">
+              <div className="flex items-start space-x-2 opacity-0 group-hover:opacity-100 focus-within:opacity-100">
                 <button className="text-gray-500 hover:text-gray-700" onClick={() => moveIncantation(index, -1)}>
                   <ArrowUp className="h-4 w-4" />
                 </button>
@@ -274,6 +330,145 @@ const EquipmentTab = ({ equipment, onChange }) => {
                 <button className="text-red-500 hover:text-red-700" onClick={() => handleRemoveIncantation(index)}>
                   <Trash2 className="h-5 w-5" />
                 </button>
+              </div>
+            </div>
+          </div>
+        ))
+      )}
+
+      {/* Weapons */}
+      <div className="flex justify-between items-center mt-8 mb-6">
+        <h3 className="text-xl font-medium">Weapons</h3>
+        <button
+          className="bg-blue-600 text-white px-4 py-2 rounded-md flex items-center"
+          onClick={handleAddWeapon}
+        >
+          <Plus className="mr-1 h-4 w-4" />
+          Add Weapon
+        </button>
+      </div>
+
+      {weapons.length === 0 ? (
+        <div className="text-center py-12 text-gray-500 bg-white p-4 rounded-lg border border-gray-200">
+          No weapons added yet.
+        </div>
+      ) : (
+        weapons.map((weapon, index) => (
+          <div key={index} className="bg-white p-4 rounded-lg border border-gray-200 mb-4 group">
+            <div className="grid grid-cols-1 md:grid-cols-4 gap-4 items-center">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Weapon Name</label>
+                <input
+                  type="text"
+                  className="w-full p-2 border border-gray-300 rounded-md"
+                  value={weapon.name || ""}
+                  onChange={(e) => handleUpdateWeapon(index, "name", e.target.value)}
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Modifier</label>
+                <input
+                  type="number"
+                  className="w-full p-2 border border-gray-300 rounded-md"
+                  value={weapon.modifier || 0}
+                  onChange={(e) => handleUpdateWeapon(index, "modifier", parseInt(e.target.value) || 0)}
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Damage</label>
+                <input
+                  type="text"
+                  className="w-full p-2 border border-gray-300 rounded-md"
+                  value={weapon.damage || ""}
+                  onChange={(e) => handleUpdateWeapon(index, "damage", e.target.value)}
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Properties</label>
+                <div className="flex items-center">
+                  <input
+                    type="text"
+                    className="flex-1 p-2 border border-gray-300 rounded-l-md"
+                    value={weapon.properties || ""}
+                    onChange={(e) => handleUpdateWeapon(index, "properties", e.target.value)}
+                  />
+                  <div className="flex flex-col opacity-0 group-hover:opacity-100 focus-within:opacity-100">
+                    <button className="text-gray-500 hover:text-gray-700" onClick={() => moveWeapon(index, -1)}>
+                      <ArrowUp className="h-4 w-4" />
+                    </button>
+                    <button className="text-gray-500 hover:text-gray-700" onClick={() => moveWeapon(index, 1)}>
+                      <ArrowDown className="h-4 w-4" />
+                    </button>
+                  </div>
+                  <button className="bg-red-500 text-white p-2 rounded-r-md hover:bg-red-600 ml-1 opacity-0 group-hover:opacity-100 focus-within:opacity-100" onClick={() => handleRemoveWeapon(index)}>
+                    <Trash2 className="h-5 w-5" />
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        ))
+      )}
+
+      {/* Armor */}
+      <div className="flex justify-between items-center mt-8 mb-6">
+        <h3 className="text-xl font-medium">Armor</h3>
+        <button
+          className="bg-blue-600 text-white px-4 py-2 rounded-md flex items-center"
+          onClick={handleAddArmor}
+        >
+          <Plus className="mr-1 h-4 w-4" />
+          Add Armor
+        </button>
+      </div>
+
+      {armor.length === 0 ? (
+        <div className="text-center py-12 text-gray-500 bg-white p-4 rounded-lg border border-gray-200">
+          No armor added yet.
+        </div>
+      ) : (
+        armor.map((a, index) => (
+          <div key={index} className="bg-white p-4 rounded-lg border border-gray-200 mb-4 group">
+            <div className="grid grid-cols-1 md:grid-cols-4 gap-4 items-center">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Armor Name</label>
+                <input
+                  type="text"
+                  className="w-full p-2 border border-gray-300 rounded-md"
+                  value={a.name || ""}
+                  onChange={(e) => handleUpdateArmor(index, "name", e.target.value)}
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Rating</label>
+                <input
+                  type="number"
+                  className="w-full p-2 border border-gray-300 rounded-md"
+                  value={a.rating || 0}
+                  onChange={(e) => handleUpdateArmor(index, "rating", parseInt(e.target.value) || 0)}
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Properties</label>
+                <div className="flex items-center">
+                  <input
+                    type="text"
+                    className="flex-1 p-2 border border-gray-300 rounded-l-md"
+                    value={a.properties || ""}
+                    onChange={(e) => handleUpdateArmor(index, "properties", e.target.value)}
+                  />
+                  <div className="flex flex-col opacity-0 group-hover:opacity-100 focus-within:opacity-100">
+                    <button className="text-gray-500 hover:text-gray-700" onClick={() => moveArmor(index, -1)}>
+                      <ArrowUp className="h-4 w-4" />
+                    </button>
+                    <button className="text-gray-500 hover:text-gray-700" onClick={() => moveArmor(index, 1)}>
+                      <ArrowDown className="h-4 w-4" />
+                    </button>
+                  </div>
+                  <button className="bg-red-500 text-white p-2 rounded-r-md hover:bg-red-600 ml-1 opacity-0 group-hover:opacity-100 focus-within:opacity-100" onClick={() => handleRemoveArmor(index)}>
+                    <Trash2 className="h-5 w-5" />
+                  </button>
+                </div>
               </div>
             </div>
           </div>

--- a/app/components/Sheet.tsx
+++ b/app/components/Sheet.tsx
@@ -104,6 +104,7 @@ const ShadowOfTheDemonLordSheet = ({
         perceptionMod: 0,
       },
       weapons: [],
+      armor: [],
       paths: {
         novice: { name: "", details: "" },
         expert: { name: "", details: "" },
@@ -130,6 +131,7 @@ const ShadowOfTheDemonLordSheet = ({
     (data as any).ancestryTraits = (data as any).ancestryTraits || [];
     (data as any).equipment = (data as any).equipment || { currency: {}, items: [], incantations: [] };
     (data as any).equipment.incantations = (data as any).equipment.incantations || [];
+    (data as any).armor = (data as any).armor || [];
 
     return data;
   });
@@ -174,6 +176,7 @@ const ShadowOfTheDemonLordSheet = ({
           ...charData.equipment,
           incantations: charData.equipment?.incantations || [],
         },
+        armor: charData.armor || [],
       };
 
       setCharacter(updated);
@@ -318,8 +321,10 @@ const ShadowOfTheDemonLordSheet = ({
               }`}
               onClick={() => handleTabChange(tab)}
             >
-              {tab.charAt(0).toUpperCase() +
-                tab.slice(1).replace(/([A-Z])/g, " $1")}
+              {tab === "weapons"
+                ? "Weapons and Armor"
+                : tab.charAt(0).toUpperCase() +
+                  tab.slice(1).replace(/([A-Z])/g, " $1")}
             </button>
           ))}
         </div>
@@ -347,8 +352,12 @@ const ShadowOfTheDemonLordSheet = ({
           {activeTab === "weapons" && (
             <WeaponsTab
               weapons={character.weapons}
-              onChange={(updatedWeapons) =>
+              armor={character.armor}
+              onWeaponsChange={(updatedWeapons) =>
                 setCharacter({ ...character, weapons: updatedWeapons })
+              }
+              onArmorChange={(updatedArmor) =>
+                setCharacter({ ...character, armor: updatedArmor })
               }
             />
           )}
@@ -395,8 +404,16 @@ const ShadowOfTheDemonLordSheet = ({
           {activeTab === "equipment" && (
             <EquipmentTab
               equipment={character.equipment}
-              onChange={(updatedEquipment) =>
-                setCharacter({ ...character, equipment: updatedEquipment })
+              weapons={character.weapons}
+              armor={character.armor}
+              onEquipmentChange={(updated) =>
+                setCharacter({ ...character, equipment: updated })
+              }
+              onWeaponsChange={(updated) =>
+                setCharacter({ ...character, weapons: updated })
+              }
+              onArmorChange={(updated) =>
+                setCharacter({ ...character, armor: updated })
               }
             />
           )}

--- a/app/components/Sheet.tsx
+++ b/app/components/Sheet.tsx
@@ -122,11 +122,14 @@ const ShadowOfTheDemonLordSheet = ({
           bits: 0,
         },
         items: [],
+        incantations: [],
       },
     };
 
     // ensure backwards compatibility fields
     (data as any).ancestryTraits = (data as any).ancestryTraits || [];
+    (data as any).equipment = (data as any).equipment || { currency: {}, items: [], incantations: [] };
+    (data as any).equipment.incantations = (data as any).equipment.incantations || [];
 
     return data;
   });
@@ -167,6 +170,10 @@ const ShadowOfTheDemonLordSheet = ({
       const updated = {
         ...charData,
         ancestryTraits: charData.ancestryTraits || [],
+        equipment: {
+          ...charData.equipment,
+          incantations: charData.equipment?.incantations || [],
+        },
       };
 
       setCharacter(updated);

--- a/app/components/SpellsTab.tsx
+++ b/app/components/SpellsTab.tsx
@@ -1,4 +1,4 @@
-import { Trash2, Plus } from "lucide-react";
+import { Trash2, Plus, ArrowUp, ArrowDown } from "lucide-react";
 
 const SpellsTab = ({ spells, onChange }) => {
   // Add a new spell
@@ -22,6 +22,15 @@ const SpellsTab = ({ spells, onChange }) => {
       [field]: value,
     };
     onChange(updatedSpells);
+  };
+
+  const moveSpell = (index, direction) => {
+    const newIndex = index + direction;
+    if (newIndex < 0 || newIndex >= spells.length) return;
+    const updated = [...spells];
+    const [moved] = updated.splice(index, 1);
+    updated.splice(newIndex, 0, moved);
+    onChange(updated);
   };
 
   return (
@@ -96,7 +105,7 @@ const SpellsTab = ({ spells, onChange }) => {
                 <label className="block text-sm font-medium text-gray-700 mb-1">
                   Castings
                 </label>
-                <div className="flex">
+                <div className="flex items-center">
                   <input
                     type="number"
                     className="flex-1 p-2 border border-gray-300 rounded-l-md"
@@ -109,8 +118,22 @@ const SpellsTab = ({ spells, onChange }) => {
                       )
                     }
                   />
+                  <div className="flex flex-col">
+                    <button
+                      className="text-gray-500 hover:text-gray-700"
+                      onClick={() => moveSpell(index, -1)}
+                    >
+                      <ArrowUp className="h-4 w-4" />
+                    </button>
+                    <button
+                      className="text-gray-500 hover:text-gray-700"
+                      onClick={() => moveSpell(index, 1)}
+                    >
+                      <ArrowDown className="h-4 w-4" />
+                    </button>
+                  </div>
                   <button
-                    className="bg-red-500 text-white p-2 rounded-r-md hover:bg-red-600"
+                    className="bg-red-500 text-white p-2 rounded-r-md hover:bg-red-600 ml-1"
                     onClick={() => handleRemoveSpell(index)}
                   >
                     <Trash2 className="h-5 w-5" />

--- a/app/components/SpellsTab.tsx
+++ b/app/components/SpellsTab.tsx
@@ -54,7 +54,7 @@ const SpellsTab = ({ spells, onChange }) => {
         spells.map((spell, index) => (
           <div
             key={index}
-            className="bg-white p-4 rounded-lg border border-gray-200 mb-4"
+            className="bg-white p-4 rounded-lg border border-gray-200 mb-4 group"
           >
             <div className="grid grid-cols-1 md:grid-cols-4 gap-4 items-center mb-4">
               <div>
@@ -118,7 +118,7 @@ const SpellsTab = ({ spells, onChange }) => {
                       )
                     }
                   />
-                  <div className="flex flex-col">
+                  <div className="flex flex-col opacity-0 group-hover:opacity-100 focus-within:opacity-100">
                     <button
                       className="text-gray-500 hover:text-gray-700"
                       onClick={() => moveSpell(index, -1)}
@@ -133,7 +133,7 @@ const SpellsTab = ({ spells, onChange }) => {
                     </button>
                   </div>
                   <button
-                    className="bg-red-500 text-white p-2 rounded-r-md hover:bg-red-600 ml-1"
+                    className="bg-red-500 text-white p-2 rounded-r-md hover:bg-red-600 ml-1 opacity-0 group-hover:opacity-100 focus-within:opacity-100"
                     onClick={() => handleRemoveSpell(index)}
                   >
                     <Trash2 className="h-5 w-5" />

--- a/app/components/SpellsTab.tsx
+++ b/app/components/SpellsTab.tsx
@@ -118,22 +118,22 @@ const SpellsTab = ({ spells, onChange }) => {
                       )
                     }
                   />
-                  <div className="flex flex-col opacity-0 group-hover:opacity-100 focus-within:opacity-100">
+                  <div className="flex flex-col">
                     <button
                       className="text-gray-500 hover:text-gray-700"
                       onClick={() => moveSpell(index, -1)}
                     >
-                      <ArrowUp className="h-4 w-4" />
+                      <ArrowUp className="h-5 w-5" />
                     </button>
                     <button
                       className="text-gray-500 hover:text-gray-700"
                       onClick={() => moveSpell(index, 1)}
                     >
-                      <ArrowDown className="h-4 w-4" />
+                      <ArrowDown className="h-5 w-5" />
                     </button>
                   </div>
                   <button
-                    className="bg-red-500 text-white p-2 rounded-r-md hover:bg-red-600 ml-1 opacity-0 group-hover:opacity-100 focus-within:opacity-100"
+                    className="bg-red-500 text-white p-2 rounded-r-md hover:bg-red-600 ml-1"
                     onClick={() => handleRemoveSpell(index)}
                   >
                     <Trash2 className="h-5 w-5" />

--- a/app/components/TalentsTab.tsx
+++ b/app/components/TalentsTab.tsx
@@ -78,22 +78,22 @@ const TalentsTab = ({ talents, onChange }) => {
                   }
                 />
               </div>
-              <div className="flex flex-col ml-2 opacity-0 group-hover:opacity-100 focus-within:opacity-100">
+              <div className="flex flex-col ml-2">
                 <button
                   className="text-gray-500 hover:text-gray-700"
                   onClick={() => moveTalent(index, -1)}
                 >
-                  <ArrowUp className="h-4 w-4" />
+                  <ArrowUp className="h-5 w-5" />
                 </button>
                 <button
                   className="text-gray-500 hover:text-gray-700"
                   onClick={() => moveTalent(index, 1)}
                 >
-                  <ArrowDown className="h-4 w-4" />
+                  <ArrowDown className="h-5 w-5" />
                 </button>
               </div>
               <button
-                className="ml-2 text-red-500 hover:text-red-700 opacity-0 group-hover:opacity-100 focus-within:opacity-100"
+                className="ml-2 text-red-500 hover:text-red-700"
                 onClick={() => handleRemoveTalent(index)}
               >
                 <Trash2 className="h-6 w-6" />

--- a/app/components/TalentsTab.tsx
+++ b/app/components/TalentsTab.tsx
@@ -51,7 +51,7 @@ const TalentsTab = ({ talents, onChange }) => {
         talents.map((talent, index) => (
           <div
             key={index}
-            className="bg-white p-4 rounded-lg border border-gray-200 mb-4"
+            className="bg-white p-4 rounded-lg border border-gray-200 mb-4 group"
           >
             <div className="flex items-start">
               <div className="flex-1">
@@ -78,7 +78,7 @@ const TalentsTab = ({ talents, onChange }) => {
                   }
                 />
               </div>
-              <div className="flex flex-col ml-2">
+              <div className="flex flex-col ml-2 opacity-0 group-hover:opacity-100 focus-within:opacity-100">
                 <button
                   className="text-gray-500 hover:text-gray-700"
                   onClick={() => moveTalent(index, -1)}
@@ -93,7 +93,7 @@ const TalentsTab = ({ talents, onChange }) => {
                 </button>
               </div>
               <button
-                className="ml-2 text-red-500 hover:text-red-700"
+                className="ml-2 text-red-500 hover:text-red-700 opacity-0 group-hover:opacity-100 focus-within:opacity-100"
                 onClick={() => handleRemoveTalent(index)}
               >
                 <Trash2 className="h-6 w-6" />

--- a/app/components/TalentsTab.tsx
+++ b/app/components/TalentsTab.tsx
@@ -1,4 +1,4 @@
-import { Trash2, Plus } from "lucide-react";
+import { Trash2, Plus, ArrowUp, ArrowDown } from "lucide-react";
 
 const TalentsTab = ({ talents, onChange }) => {
   // Add a new talent
@@ -19,6 +19,15 @@ const TalentsTab = ({ talents, onChange }) => {
       [field]: value,
     };
     onChange(updatedTalents);
+  };
+
+  const moveTalent = (index, direction) => {
+    const newIndex = index + direction;
+    if (newIndex < 0 || newIndex >= talents.length) return;
+    const updated = [...talents];
+    const [moved] = updated.splice(index, 1);
+    updated.splice(newIndex, 0, moved);
+    onChange(updated);
   };
 
   return (
@@ -69,8 +78,22 @@ const TalentsTab = ({ talents, onChange }) => {
                   }
                 />
               </div>
+              <div className="flex flex-col ml-2">
+                <button
+                  className="text-gray-500 hover:text-gray-700"
+                  onClick={() => moveTalent(index, -1)}
+                >
+                  <ArrowUp className="h-4 w-4" />
+                </button>
+                <button
+                  className="text-gray-500 hover:text-gray-700"
+                  onClick={() => moveTalent(index, 1)}
+                >
+                  <ArrowDown className="h-4 w-4" />
+                </button>
+              </div>
               <button
-                className="ml-4 text-red-500 hover:text-red-700"
+                className="ml-2 text-red-500 hover:text-red-700"
                 onClick={() => handleRemoveTalent(index)}
               >
                 <Trash2 className="h-6 w-6" />

--- a/app/components/WeaponsTab.tsx
+++ b/app/components/WeaponsTab.tsx
@@ -1,4 +1,4 @@
-import { Trash2, Plus } from "lucide-react";
+import { Trash2, Plus, ArrowUp, ArrowDown } from "lucide-react";
 
 const WeaponsTab = ({ weapons, onChange }) => {
   // Add a new weapon
@@ -7,6 +7,15 @@ const WeaponsTab = ({ weapons, onChange }) => {
       ...weapons,
       { name: "", modifier: 0, damage: "", properties: "" },
     ]);
+  };
+
+  const moveWeapon = (index, direction) => {
+    const newIndex = index + direction;
+    if (newIndex < 0 || newIndex >= weapons.length) return;
+    const updated = [...weapons];
+    const [moved] = updated.splice(index, 1);
+    updated.splice(newIndex, 0, moved);
+    onChange(updated);
   };
 
   // Remove a weapon
@@ -84,7 +93,7 @@ const WeaponsTab = ({ weapons, onChange }) => {
               <label className="block text-sm font-medium text-gray-700 mb-1">
                 Properties
               </label>
-              <div className="flex">
+              <div className="flex items-center">
                 <input
                   type="text"
                   className="flex-1 p-2 border border-gray-300 rounded-l-md"
@@ -93,8 +102,22 @@ const WeaponsTab = ({ weapons, onChange }) => {
                     handleUpdateWeapon(index, "properties", e.target.value)
                   }
                 />
+                <div className="flex flex-col">
+                  <button
+                    className="text-gray-500 hover:text-gray-700"
+                    onClick={() => moveWeapon(index, -1)}
+                  >
+                    <ArrowUp className="h-4 w-4" />
+                  </button>
+                  <button
+                    className="text-gray-500 hover:text-gray-700"
+                    onClick={() => moveWeapon(index, 1)}
+                  >
+                    <ArrowDown className="h-4 w-4" />
+                  </button>
+                </div>
                 <button
-                  className="bg-red-500 text-white p-2 rounded-r-md hover:bg-red-600"
+                  className="bg-red-500 text-white p-2 rounded-r-md hover:bg-red-600 ml-1"
                   onClick={() => handleRemoveWeapon(index)}
                 >
                   <Trash2 className="h-5 w-5" />

--- a/app/components/WeaponsTab.tsx
+++ b/app/components/WeaponsTab.tsx
@@ -131,22 +131,22 @@ const WeaponsTab = ({ weapons, armor, onWeaponsChange, onArmorChange }) => {
                     handleUpdateWeapon(index, "properties", e.target.value)
                   }
                 />
-                <div className="flex flex-col opacity-0 group-hover:opacity-100 focus-within:opacity-100">
+                <div className="flex flex-col">
                   <button
                     className="text-gray-500 hover:text-gray-700"
                     onClick={() => moveWeapon(index, -1)}
                   >
-                    <ArrowUp className="h-4 w-4" />
+                    <ArrowUp className="h-5 w-5" />
                   </button>
                   <button
                     className="text-gray-500 hover:text-gray-700"
                     onClick={() => moveWeapon(index, 1)}
                   >
-                    <ArrowDown className="h-4 w-4" />
+                    <ArrowDown className="h-5 w-5" />
                   </button>
                 </div>
                 <button
-                  className="bg-red-500 text-white p-2 rounded-r-md hover:bg-red-600 ml-1 opacity-0 group-hover:opacity-100 focus-within:opacity-100"
+                  className="bg-red-500 text-white p-2 rounded-r-md hover:bg-red-600 ml-1"
                   onClick={() => handleRemoveWeapon(index)}
                 >
                   <Trash2 className="h-5 w-5" />
@@ -215,22 +215,22 @@ const WeaponsTab = ({ weapons, armor, onWeaponsChange, onArmorChange }) => {
                     handleUpdateArmor(index, "properties", e.target.value)
                   }
                 />
-                <div className="flex flex-col opacity-0 group-hover:opacity-100 focus-within:opacity-100">
+                <div className="flex flex-col">
                   <button
                     className="text-gray-500 hover:text-gray-700"
                     onClick={() => moveArmor(index, -1)}
                   >
-                    <ArrowUp className="h-4 w-4" />
+                    <ArrowUp className="h-5 w-5" />
                   </button>
                   <button
                     className="text-gray-500 hover:text-gray-700"
                     onClick={() => moveArmor(index, 1)}
                   >
-                    <ArrowDown className="h-4 w-4" />
+                    <ArrowDown className="h-5 w-5" />
                   </button>
                 </div>
                 <button
-                  className="bg-red-500 text-white p-2 rounded-r-md hover:bg-red-600 ml-1 opacity-0 group-hover:opacity-100 focus-within:opacity-100"
+                  className="bg-red-500 text-white p-2 rounded-r-md hover:bg-red-600 ml-1"
                   onClick={() => handleRemoveArmor(index)}
                 >
                   <Trash2 className="h-5 w-5" />

--- a/app/components/WeaponsTab.tsx
+++ b/app/components/WeaponsTab.tsx
@@ -1,9 +1,9 @@
 import { Trash2, Plus, ArrowUp, ArrowDown } from "lucide-react";
 
-const WeaponsTab = ({ weapons, onChange }) => {
+const WeaponsTab = ({ weapons, armor, onWeaponsChange, onArmorChange }) => {
   // Add a new weapon
   const handleAddWeapon = () => {
-    onChange([
+    onWeaponsChange([
       ...weapons,
       { name: "", modifier: 0, damage: "", properties: "" },
     ]);
@@ -15,12 +15,12 @@ const WeaponsTab = ({ weapons, onChange }) => {
     const updated = [...weapons];
     const [moved] = updated.splice(index, 1);
     updated.splice(newIndex, 0, moved);
-    onChange(updated);
+    onWeaponsChange(updated);
   };
 
   // Remove a weapon
   const handleRemoveWeapon = (index) => {
-    onChange(weapons.filter((_, i) => i !== index));
+    onWeaponsChange(weapons.filter((_, i) => i !== index));
   };
 
   // Update a weapon property
@@ -30,7 +30,36 @@ const WeaponsTab = ({ weapons, onChange }) => {
       ...updatedWeapons[index],
       [field]: value,
     };
-    onChange(updatedWeapons);
+    onWeaponsChange(updatedWeapons);
+  };
+
+  // ------------------
+  // Armor helpers
+  // ------------------
+  const handleAddArmor = () => {
+    onArmorChange([
+      ...armor,
+      { name: "", rating: 0, properties: "" },
+    ]);
+  };
+
+  const moveArmor = (index, direction) => {
+    const newIndex = index + direction;
+    if (newIndex < 0 || newIndex >= armor.length) return;
+    const updated = [...armor];
+    const [moved] = updated.splice(index, 1);
+    updated.splice(newIndex, 0, moved);
+    onArmorChange(updated);
+  };
+
+  const handleRemoveArmor = (index) => {
+    onArmorChange(armor.filter((_, i) => i !== index));
+  };
+
+  const handleUpdateArmor = (index, field, value) => {
+    const updated = [...armor];
+    updated[index] = { ...updated[index], [field]: value };
+    onArmorChange(updated);
   };
 
   return (
@@ -40,7 +69,7 @@ const WeaponsTab = ({ weapons, onChange }) => {
       {weapons.map((weapon, index) => (
         <div
           key={index}
-          className="bg-white p-4 rounded-lg border border-gray-200 mb-4"
+          className="bg-white p-4 rounded-lg border border-gray-200 mb-4 group"
         >
           <div className="grid grid-cols-1 md:grid-cols-4 gap-4 items-center">
             <div>
@@ -102,7 +131,7 @@ const WeaponsTab = ({ weapons, onChange }) => {
                     handleUpdateWeapon(index, "properties", e.target.value)
                   }
                 />
-                <div className="flex flex-col">
+                <div className="flex flex-col opacity-0 group-hover:opacity-100 focus-within:opacity-100">
                   <button
                     className="text-gray-500 hover:text-gray-700"
                     onClick={() => moveWeapon(index, -1)}
@@ -117,7 +146,7 @@ const WeaponsTab = ({ weapons, onChange }) => {
                   </button>
                 </div>
                 <button
-                  className="bg-red-500 text-white p-2 rounded-r-md hover:bg-red-600 ml-1"
+                  className="bg-red-500 text-white p-2 rounded-r-md hover:bg-red-600 ml-1 opacity-0 group-hover:opacity-100 focus-within:opacity-100"
                   onClick={() => handleRemoveWeapon(index)}
                 >
                   <Trash2 className="h-5 w-5" />
@@ -134,6 +163,90 @@ const WeaponsTab = ({ weapons, onChange }) => {
       >
         <Plus className="mr-1 h-4 w-4" />
         Add Weapon
+      </button>
+
+      {/* Armor Section */}
+      <h2 className="text-2xl font-bold mt-10 mb-6">Armor</h2>
+
+      {armor.map((a, index) => (
+        <div
+          key={index}
+          className="bg-white p-4 rounded-lg border border-gray-200 mb-4 group"
+        >
+          <div className="grid grid-cols-1 md:grid-cols-4 gap-4 items-center">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Armor Name
+              </label>
+              <input
+                type="text"
+                className="w-full p-2 border border-gray-300 rounded-md"
+                value={a.name || ""}
+                onChange={(e) =>
+                  handleUpdateArmor(index, "name", e.target.value)
+                }
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Rating
+              </label>
+              <input
+                type="number"
+                className="w-full p-2 border border-gray-300 rounded-md"
+                value={a.rating || 0}
+                onChange={(e) =>
+                  handleUpdateArmor(index, "rating", parseInt(e.target.value) || 0)
+                }
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Properties
+              </label>
+              <div className="flex items-center">
+                <input
+                  type="text"
+                  className="flex-1 p-2 border border-gray-300 rounded-l-md"
+                  value={a.properties || ""}
+                  onChange={(e) =>
+                    handleUpdateArmor(index, "properties", e.target.value)
+                  }
+                />
+                <div className="flex flex-col opacity-0 group-hover:opacity-100 focus-within:opacity-100">
+                  <button
+                    className="text-gray-500 hover:text-gray-700"
+                    onClick={() => moveArmor(index, -1)}
+                  >
+                    <ArrowUp className="h-4 w-4" />
+                  </button>
+                  <button
+                    className="text-gray-500 hover:text-gray-700"
+                    onClick={() => moveArmor(index, 1)}
+                  >
+                    <ArrowDown className="h-4 w-4" />
+                  </button>
+                </div>
+                <button
+                  className="bg-red-500 text-white p-2 rounded-r-md hover:bg-red-600 ml-1 opacity-0 group-hover:opacity-100 focus-within:opacity-100"
+                  onClick={() => handleRemoveArmor(index)}
+                >
+                  <Trash2 className="h-5 w-5" />
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      ))}
+
+      <button
+        className="bg-blue-600 text-white px-4 py-2 rounded-md flex items-center"
+        onClick={handleAddArmor}
+      >
+        <Plus className="mr-1 h-4 w-4" />
+        Add Armor
       </button>
     </div>
   );

--- a/app/routes/sheet.tsx
+++ b/app/routes/sheet.tsx
@@ -23,7 +23,7 @@ export function meta({ matches }: Route.MetaArgs) {
 
 export async function loader({ context, params }: Route.LoaderArgs) {
   const durableObjectId = context.cloudflare.env.SHEET_STORE.idFromName(
-    params.id || ""
+    (params as any).id || ""
   );
   const dObj = context.cloudflare.env.SHEET_STORE.get(durableObjectId);
   // @ts-ignore
@@ -33,7 +33,7 @@ export async function loader({ context, params }: Route.LoaderArgs) {
 export async function action({ request, params, context }: Route.ActionArgs) {
   let data = await request.json();
   const durableObjectId = context.cloudflare.env.SHEET_STORE.idFromName(
-    params.id || ""
+    (params as any).id || ""
   );
   const dObj = context.cloudflare.env.SHEET_STORE.get(durableObjectId);
   await dObj.saveData(data);

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -2,4 +2,5 @@
 
 interface Env {
 	VALUE_FROM_CLOUDFLARE: "Hello from Cloudflare";
+	SHEET_STORE: DurableObjectNamespace<import("./workers/app").SheetStore>;
 }


### PR DESCRIPTION
## Summary
- add incantations section to equipment
- allow reordering in equipment, weapons, spells, talents and ancestry traits
- keep incantations in saved character data
- fix loader/action typing for wrangler typecheck
- update worker configuration after generating types

## Testing
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_b_68516003b844832c91b868bdc6464185