### PR TITLE
Add power field for companions

### DIFF
--- a/app/components/CompanionsTab.tsx
+++ b/app/components/CompanionsTab.tsx
@@ -12,6 +12,7 @@ const CompanionsTab = ({ companions, onChange }) => {
         perception: 10,
         health: 0,
         defense: 0,
+        power: 0,
         insanity: 0,
         corruption: 0,
         strength: 10,
@@ -211,6 +212,23 @@ const CompanionsTab = ({ companions, onChange }) => {
                     handleUpdateCompanion(
                       index,
                       "defense",
+                      parseInt(e.target.value) || 0
+                    )
+                  }
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Power
+                </label>
+                <input
+                  type="number"
+                  className="w-full p-2 border border-gray-300 rounded-md"
+                  value={companion.power || 0}
+                  onChange={(e) =>
+                    handleUpdateCompanion(
+                      index,
+                      "power",
                       parseInt(e.target.value) || 0
                     )
                   }


### PR DESCRIPTION
### Motivation
- Add a numeric Power attribute to companions so users can set and save a companion Power stat alongside existing stats.

### Description
- Add `power: 0` to the default companion object created in `handleAddCompanion` and render a new numeric input labeled "Power" bound to `companion.power` that updates via `handleUpdateCompanion`.

### Testing
- Attempted to start the dev server with `npm run dev`, which failed due to a React Router/Vite config flag error (`future.unstable_viteEnvironmentApi`), and a subsequent Playwright UI check could not connect to the app because the server did not come up.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696a0bc406b083318da24b6524e627c3)